### PR TITLE
Fixing an infinite loop.

### DIFF
--- a/src/Emitters/CurlEmitter.php
+++ b/src/Emitters/CurlEmitter.php
@@ -143,8 +143,10 @@ class CurlEmitter extends Emitter {
 
         // Execute the rolling curl
         do {
-            $execrun = curl_multi_exec($master, $running);
-            while ($execrun == CURLM_CALL_MULTI_PERFORM);
+            do {
+                $execrun = curl_multi_exec($master, $running);
+            } while ($execrun == CURLM_CALL_MULTI_PERFORM);
+
             while ($done = curl_multi_info_read($master)) {
                 if ($debug) {
                     $info = curl_getinfo($done['handle']);


### PR DESCRIPTION
I was having trouble getting the PHPUnit tests to run locally and traced it to an infinite loop on line 147. I _think_ it just needed a do while loop around that individual call. as curl_multi_exec should just be recalled again if CURLM_CALL_MULTI_PERFORM is returned.