### PR TITLE
Generate a true uuid for events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "email": "support@snowplowanalytics.com"
     },
     "require": {
-        "rmccue/requests": ">=1.0"
+        "rmccue/requests": ">=1.0",
+        "rhumsaa/uuid": "2.8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.*",

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -23,6 +23,8 @@
 
 namespace Snowplow\Tracker;
 
+use Rhumsaa\Uuid\Uuid;
+
 class Tracker extends Constants {
 
     // Tracker Parameters
@@ -149,7 +151,11 @@ class Tracker extends Constants {
      * @return string - Unique String based on the time of creation
      */
     private function generateUuid() {
-        return uniqid("", true);
+        if (function_exists('uuid_create'))
+        {
+            return uuid_create(UUID_TYPE_TIME);
+        }
+        return Uuid::uuid1()->toString();
     }
 
     /**

--- a/tests/tests/ClassInitTests/TrackerTest.php
+++ b/tests/tests/ClassInitTests/TrackerTest.php
@@ -107,4 +107,23 @@ class TrackerTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(2, count($tracker->returnEmitters()));
         $tracker->turnOffDebug(true);
     }
+
+    public function testEventIdIsProperlyGenerated()
+    {
+        $emitter = $this->getMockBuilder('Snowplow\Tracker\Emitter')->getMock();
+
+        $test = $this;
+        $emitter->expects($this->once())
+            ->method('addEvent')
+            ->with($this->callback(function ($a) use($test) {
+                $test->assertArrayHasKey('eid', $a);
+                $test->assertRegExp('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/', $a['eid']);
+
+                return true;
+            }));
+
+        $tracker = new Tracker($this->e1, $this->s1, "namespace", "app_id", false);
+        $tracker->addEmitter($emitter);
+        $tracker->trackPageView("http:/example.com");
+    }
 }


### PR DESCRIPTION
Attempts to use the uuid extension if it exists. If it does not it falls back to a php uuid library. This does introduce a new required dependency. This resolves issue #39.

Also, if the build fails in the curl emitter that is likely due to:
https://github.com/snowplow/snowplow-php-tracker/pull/40

I figured it made sense to keep the PRs separate as you guys may want to go a different direction with UUIDs.

The dependency involved can be found at: https://github.com/ramsey/uuid