### PR TITLE
fix rmccue/requests version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "support@snowplowanalytics.com"
     },
     "require": {
-        "rmccue/requests": ">=1.0",
+        "rmccue/requests": "^1.0",
         "ramsey/uuid": "^3.5"
     },
     "require-dev": {


### PR DESCRIPTION
would be bad otherwise if rmccue/requests released a 2.0 version that broke compability
