### PR TITLE
Replace rhumsaa/uuid dependency with ramsey/uuid 3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,12 @@
     },
     "require": {
         "rmccue/requests": ">=1.0",
-        "rhumsaa/uuid": "2.8.*"
+        "ramsey/uuid": "^3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",
         "satooshi/php-coveralls": "dev-master"
     },
-    "homepage": "http://snowplowanalytics.com/",
     "autoload": {
         "psr-4": {
             "Snowplow\\Tracker\\": "src"

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -23,7 +23,7 @@
 
 namespace Snowplow\Tracker;
 
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 class Tracker extends Constants {
 


### PR DESCRIPTION
The `rhumsaa/uuid` library was outdated and needs to be fixed to avoid conflicts going forward.