### PR TITLE
 Remove deprecated $errcontext from custom error handler

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -119,7 +119,7 @@ class Constants {
      * Custom handler to turn all PHP Warnings into ErrorExceptions
      */
     public function warning_handler() {
-        set_error_handler(function($errno, $errstr, $errfile, $errline, array $errcontext) {
+        set_error_handler(function($errno, $errstr, $errfile, $errline) {
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }, E_WARNING);
     }


### PR DESCRIPTION
`$errcontext` is an optional parameter deprecated on custom error handlers as of PHP 7.2.0

It is also unused in `Constants::warning_handler()`