### PR TITLE
Allow tracking with the session ID

### DIFF
--- a/src/Subject.php
+++ b/src/Subject.php
@@ -66,6 +66,15 @@ class Subject extends Constants {
     }
 
     /**
+     * Sets a custom session identification for the event
+     *
+     * @param string $sessionId
+     */
+    public function setSessionId($sessionId) {
+        $this->tracker_settings["sid"] = $sessionId;
+    }
+
+    /**
      * Sets the screen resolution
      *
      * @param int $width
@@ -167,7 +176,7 @@ class Subject extends Constants {
     }
 
     // Subject Return Functions
-    
+
     public function returnTrackerSettings() {
         return $this->tracker_settings;
     }

--- a/tests/tests/ClassInitTests/SubjectTest.php
+++ b/tests/tests/ClassInitTests/SubjectTest.php
@@ -68,6 +68,14 @@ class SubjectTest extends TestCase {
         $this->assertEquals("user_id_1", $settings["uid"]);
     }
 
+    public function testAddSessionId() {
+        $sessionId = '50656436-A73A-4C4C-BBDF-604BCAC8D907';
+        $this->subject->setSessionId($sessionId);
+        $settings = $this->getTrackerSettings();
+        $this->assertArrayHasKey("sid", $settings);
+        $this->assertEquals($sessionId, $settings["sid"]);
+    }
+
     public function testAddScreenRes() {
         $this->subject->setScreenResolution(1024, 768);
         $settings = $this->getTrackerSettings();


### PR DESCRIPTION
The "sid" parameter that maps to the "domain_sessionid" [1] field is
present across different event types, as "domain_sessionid" is a common
field regardless of the event or platform [2].

This commit introduces the ability to define the session-id by the
"Subject" object.

[1]: https://github.com/snowplow/snowplow/wiki/snowplow-tracker-protocol
[2]: https://github.com/snowplow/snowplow/wiki/canonical-event-model