### PR TITLE
feat: updated ramsey/uuid to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.2",
         "rmccue/requests": ">=1.7",
-        "ramsey/uuid": "3.8.0"
+        "ramsey/uuid": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.1.4",


### PR DESCRIPTION
In order to upgrade Laravel to 8, we need to upgrade ramsey/uuid to version 4