### PR TITLE
Add a setter for session ID on a subject

### DIFF
--- a/src/Subject.php
+++ b/src/Subject.php
@@ -149,6 +149,15 @@ class Subject extends Constants {
     }
 
     /**
+     * Sets the Session ID
+     *
+     * @param string $sessionId
+     */
+    public function setSessionId($sessionId) {
+        $this->tracker_settings["sid"] = $sessionId;
+    }
+
+    /**
      * Sets the referer
      *
      * @param string $refr

--- a/src/Subject.php
+++ b/src/Subject.php
@@ -158,6 +158,15 @@ class Subject extends Constants {
     }
 
     /**
+     * Sets the Session Index
+     *
+     * @param int $sessionIndex
+     */
+    public function setSessionIndex($sessionIndex) {
+        $this->tracker_settings["vid"] = $sessionIndex;
+    }
+
+    /**
      * Sets the referer
      *
      * @param string $refr

--- a/tests/tests/ClassInitTests/SubjectTest.php
+++ b/tests/tests/ClassInitTests/SubjectTest.php
@@ -130,4 +130,11 @@ class SubjectTest extends TestCase {
         $this->assertArrayHasKey("tnuid", $settings);
         $this->assertEquals("tnuid", $settings["tnuid"]);
     }
+
+    public function testAddSessionId() {
+        $this->subject->setSessionId("759e1c9a-6b74-403c-8b6f-18eb9f0c2f02");
+        $settings = $this->getTrackerSettings();
+        $this->assertArrayHasKey("sid", $settings);
+        $this->assertEquals("759e1c9a-6b74-403c-8b6f-18eb9f0c2f02", $settings["sid"]);
+    }
 }

--- a/tests/tests/ClassInitTests/SubjectTest.php
+++ b/tests/tests/ClassInitTests/SubjectTest.php
@@ -137,4 +137,11 @@ class SubjectTest extends TestCase {
         $this->assertArrayHasKey("sid", $settings);
         $this->assertEquals("759e1c9a-6b74-403c-8b6f-18eb9f0c2f02", $settings["sid"]);
     }
+
+    public function testAddSessionIndex() {
+        $this->subject->setSessionIndex(1);
+        $settings = $this->getTrackerSettings();
+        $this->assertArrayHasKey("vid", $settings);
+        $this->assertEquals(1, $settings["vid"]);
+    }
 }


### PR DESCRIPTION
The [Snowplow Tracker Protocol](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/) allows a unique identifier (UUID) for a session (`sid`). The current version of the PHP Tracker does not support adding a session ID to a subject. This pull request adds this feature.

Usage:
``` php
$subject = new \Snowplow\Tracker\Subject;

$subject->setSessionId('759e1c9a-6b74-403c-8b6f-18eb9f0c2f02');
```