### PR TITLE
Allow log dir to be overridden for FileEmitter

### DIFF
--- a/src/Emitters/FileEmitter.php
+++ b/src/Emitters/FileEmitter.php
@@ -49,8 +49,9 @@ class FileEmitter extends Emitter {
      * @param int|float|null $timeout
      * @param int|null $buffer_size
      * @param bool|null $debug
+     * @param string|null $log_dir
      */
-    public function __construct($uri, $protocol = NULL, $type = NULL, $workers = NULL, $timeout = NULL, $buffer_size = NULL, $debug = false) {
+    public function __construct($uri, $protocol = NULL, $type = NULL, $workers = NULL, $timeout = NULL, $buffer_size = NULL, $debug = false, $log_dir = NULL) {
 
         // Set error handler to catch warnings
         $this->warning_handler();
@@ -60,7 +61,7 @@ class FileEmitter extends Emitter {
 
         $this->type     = $this->getRequestType($type);
         $this->url      = $this->getCollectorUrl($this->type, $uri, $protocol);
-        $this->log_dir  = $this->worker_root.self::WORKER_FOLDER;
+        $this->log_dir  = $log_dir ?: $this->worker_root.self::WORKER_FOLDER;
 
         // Initilize the event log file
         $this->log_file = $this->initLogFile();

--- a/tests/tests/EmitterTests/FileEmitterTest.php
+++ b/tests/tests/EmitterTests/FileEmitterTest.php
@@ -121,4 +121,11 @@ class FileEmitterTest extends TestCase {
         $this->assertEquals($root_dir."/temp/w1/",
             $paths[1]);
     }
+
+    public function testLogDirOverridden() {
+        $log_dir = "/tmp/snowplow/";
+        $emitter = new FileEmitter($this->uri, false, "POST", 3, 3, 100, false, $log_dir);
+
+        $this->assertEquals($log_dir, $emitter->returnLogDir());
+    }
 }


### PR DESCRIPTION
This allows the `$log_dir` value to be set differently than just wherever the library is installed, for environments where the `vendor` directory is not writeable. When constructing the FileEmitter, a user can now specify some other directory like `/tmp/` for the various event and worker subdirectories to be created.

I've added a test to prove the logic works.