### PR TITLE
Fix schema versions in the tests (close #119)

### DIFF
--- a/tests/tests/IntegrationTest.php
+++ b/tests/tests/IntegrationTest.php
@@ -69,14 +69,14 @@ class IntegrationTest extends TestCase {
 
     private function getContext() {
         return array(
-            "schema" => "iglu:com.acme_company/context_example/jsonschema/2.1.1",
+            "schema" => "iglu:com.acme_company/context_example/jsonschema/2-1-1",
             "data" => array("movie_name" => "Solaris", "poster_country" => "JP", "poster_year" => 1978)
         );
     }
 
     private function getUnstructEvent() {
         return array(
-            "schema" => "com.example_company/save-game/jsonschema/1.0.2",
+            "schema" => "com.example_company/save-game/jsonschema/1-0-2",
             "data" => array("save_id" => "4321", "level" => 23, "difficultyLevel" => "HARD", "dl_content" => True)
         );
     }


### PR DESCRIPTION
Issue #119 

Fixes the version strings in schemas used in tests to contain dashes instead of dots separating the parts.