### PR TITLE
Prevent deprecation warning for dynamic property creation under PHP 8.2.

### DIFF
--- a/src/Emitters/SyncEmitter.php
+++ b/src/Emitters/SyncEmitter.php
@@ -30,6 +30,7 @@ class SyncEmitter extends Emitter {
 
     private $type;
     private $url;
+    private $debug;
 
     /**
      * Creates a Synchronous Emitter


### PR DESCRIPTION
See issue #123.