### PR TITLE
Fix failing emitter tests (close #125)

### DIFF
--- a/tests/tests/EmitterTests/CurlEmitterTest.php
+++ b/tests/tests/EmitterTests/CurlEmitterTest.php
@@ -55,7 +55,7 @@ class CurlEmitterTest extends TestCase {
     // Tests
 
     public function testCurlPostBadUri() {
-        $tracker = $this->returnTracker("POST", true, "collector.acme.au");
+        $tracker = $this->returnTracker("POST", true, "snowplow-unregistered-url.this-should-fail.io");
         $tracker->flushEmitters();
         for ($i = 0; $i < 1; $i++) {
             $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
@@ -68,7 +68,7 @@ class CurlEmitterTest extends TestCase {
     }
 
     public function testCurlGetBadUri() {
-        $tracker = $this->returnTracker("GET", true, "collector.acme.au");
+        $tracker = $this->returnTracker("GET", true, "snowplow-unregistered-url.this-should-fail.io");
         $tracker->flushEmitters();
         for ($i = 0; $i < 1; $i++) {
             $tracker->trackPageView("www.example.com", "example", "www.referrer.com");

--- a/tests/tests/EmitterTests/SyncEmitterTest.php
+++ b/tests/tests/EmitterTests/SyncEmitterTest.php
@@ -55,7 +55,7 @@ class SyncEmitterTest extends TestCase {
     // Tests
 
     public function testSyncPostBadUri() {
-        $tracker = $this->returnTracker("POST", true, "collector.acme.au");
+        $tracker = $this->returnTracker("POST", true, "snowplow-unregistered-url.this-should-fail.io");
         $tracker->flushEmitters();
         for ($i = 0; $i < 1; $i++) {
             $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
@@ -68,7 +68,7 @@ class SyncEmitterTest extends TestCase {
     }
 
     public function testSyncGetBadUri() {
-        $tracker = $this->returnTracker("GET", true, "collector.acme.au");
+        $tracker = $this->returnTracker("GET", true, "snowplow-unregistered-url.this-should-fail.io");
         $tracker->flushEmitters();
         for ($i = 0; $i < 1; $i++) {
             $tracker->trackPageView("www.example.com", "example", "www.referrer.com");


### PR DESCRIPTION
For issue #125

Four of the Emitter tests relied on a URL being invalid. But it wasn't anymore! This changes replaces that URL with a new one which hopefully will never be valid.