### PR TITLE
Prevent deprecation warning for dynamic property creation under PHP 8.2 (close #123)

### DIFF
--- a/src/Emitters/CurlEmitter.php
+++ b/src/Emitters/CurlEmitter.php
@@ -28,6 +28,9 @@ class CurlEmitter extends Emitter {
 
     private $type;
     private $url;
+    private $debug;
+    private $requests_results;
+    private $debug_payloads;
 
     // Curl Specific Parameters
 

--- a/src/Emitters/SocketEmitter.php
+++ b/src/Emitters/SocketEmitter.php
@@ -31,6 +31,8 @@ class SocketEmitter extends Emitter {
     private $ssl;
     private $type;
     private $timeout;
+    private $debug;
+    private $requests_results;
 
     // Socket Parameters
 

--- a/src/Emitters/SyncEmitter.php
+++ b/src/Emitters/SyncEmitter.php
@@ -30,6 +30,7 @@ class SyncEmitter extends Emitter {
 
     private $type;
     private $url;
+    private $debug;
 
     /**
      * Creates a Synchronous Emitter

--- a/src/Emitters/SyncEmitter.php
+++ b/src/Emitters/SyncEmitter.php
@@ -31,6 +31,7 @@ class SyncEmitter extends Emitter {
     private $type;
     private $url;
     private $debug;
+    private $requests_results;
 
     /**
      * Creates a Synchronous Emitter

--- a/tests/tests/ClassInitTests/TrackerTest.php
+++ b/tests/tests/ClassInitTests/TrackerTest.php
@@ -127,7 +127,7 @@ class TrackerTest extends TestCase {
             ->method('addEvent')
             ->with($this->callback(function ($a) use($test) {
                 $test->assertArrayHasKey('eid', $a);
-                $test->assertRegExp('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/', $a['eid']);
+                $test->assertMatchesRegularExpression('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/', $a['eid']);
 
                 return true;
             }));


### PR DESCRIPTION
For issue #123

Removes annoying "Creation of dynamic property" deprecation notices, as well fixing a warning for a deprecated test assertion.

Thanks @ldebrouwer for raising this and contributing!

