### PR TITLE
Fix curl_multi_exec deprecated functionality error (close #121)

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -303,6 +303,7 @@ function execute($curls, $rolling_window) {
     }
 
     // Execute the rolling curl
+    $running = 0;
     do {
         $execrun = curl_multi_exec($master, $running);
         while ($execrun == CURLM_CALL_MULTI_PERFORM);

--- a/src/Emitters/CurlEmitter.php
+++ b/src/Emitters/CurlEmitter.php
@@ -173,6 +173,7 @@ class CurlEmitter extends Emitter {
         }
 
         // Execute the rolling curl
+        $running = 0;
         do {
             do {
                 $execrun = curl_multi_exec($master, $running);


### PR DESCRIPTION
For issue #121.

A Fatal error has been reported, caused by deprecation changes in the behaviour of `curl_multi_exec()`. This is a known problem, see e.g. [this StackOverflow question](https://stackoverflow.com/questions/72626858/curl-multi-exec-passing-null-to-parameter-still-running-of-type-int-is-depreca).

I wasn't able to reproduce the error.

The problem appears to be the `$running` variable which is passed to `curl_multi_exec()`: it should be an Int, but is null. Strangely, `$running` wasn't actually defined in the code. This change declares it as an Int.