### PR TITLE
Release/0.6.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.6.1 (2022-12-21)
+--------------------------
+Fix curl_multi_exec deprecated functionality error (#121)
+
 Version 0.6.0 (2022-12-20)
 --------------------------
 Bump dependencies (#131)

--- a/Worker.php
+++ b/Worker.php
@@ -303,6 +303,7 @@ function execute($curls, $rolling_window) {
     }
 
     // Execute the rolling curl
+    $running = 0;
     do {
         $execrun = curl_multi_exec($master, $running);
         while ($execrun == CURLM_CALL_MULTI_PERFORM);

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -45,7 +45,7 @@ class Constants {
      * - SSL: the default for whether or not to use SSL Encryption
      * - Type: the default for what type of request the emitter will be making (POST or GET)
      */
-    const TRACKER_VERSION       = "php-0.6.0";
+    const TRACKER_VERSION       = "php-0.6.1";
     const DEFAULT_BASE_64       = true;
     const DEBUG_LOG_FILES       = true;
     const CONTEXT_SCHEMA        = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";

--- a/src/Emitters/CurlEmitter.php
+++ b/src/Emitters/CurlEmitter.php
@@ -173,6 +173,7 @@ class CurlEmitter extends Emitter {
         }
 
         // Execute the rolling curl
+        $running = 0;
         do {
             do {
                 $execrun = curl_multi_exec($master, $running);


### PR DESCRIPTION
This release fixes a bug relating to a deprecated behaviour in `curl_multi_exec()`. 

**CHANGELOG**
Fix curl_multi_exec deprecated functionality error (#121)