### PR TITLE
Fixed reference to object

### DIFF
--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -36,7 +36,7 @@ class Tracker extends Constants {
     /**
      * Constructs a new tracker object with emitter(s) and a subject.
      *
-     * @param emitter|array $emitter - Emitter object, used for sending event payloads to for processing
+     * @param Emitter|array $emitter - Emitter object, used for sending event payloads to for processing
      * @param subject $subject - Subject object, contains extra information which is parcelled with the event
      * @param string|null $namespace
      * @param string|null $app_id


### PR DESCRIPTION
The object referenced in the PHP doc is lowercased, but the actual class is camelCased. By using the same casing, we ensure that the IDE and any static analyzer understands the reference.