### PR TITLE
Add retry capability for events that failed to send to collector in socket and sync emitter (close #135)

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -60,6 +60,7 @@ class Constants {
     const DEFAULT_PROTOCOL      = "http";
     const DEFAULT_SSL           = false;
     const DEFAULT_REQ_TYPE      = "POST";
+    const NO_RETRY_STATUS_CODES = array(400, 401, 403, 410, 422);
 
     /**
      * Settings for the Synchronous Emitter

--- a/src/Emitters/RetryRequestManager.php
+++ b/src/Emitters/RetryRequestManager.php
@@ -24,14 +24,14 @@ namespace Snowplow\Tracker\Emitters;
 class RetryRequestManager {
     /// The number of times the current request has been retried
     private int $retry_count = 0;
-    /// The maximum number of times to retry a request
+    /// The maximum number of times to retry a request. Defaults to 1.
     private int $max_retry_attempts;
-    /// The number of milliseconds to backoff before retrying a request
+    /// The number of milliseconds to backoff before retrying a request. Defaults to 100ms.
     private int $backoff_ms;
 
     public function __construct(int $max_retry_attempts = NULL, int $backoff_ms = NULL) {
         $this->max_retry_attempts = $max_retry_attempts == NULL ? 1 : $max_retry_attempts;
-        $this->backoff_ms = $backoff_ms == NULL ? 10 : $backoff_ms;
+        $this->backoff_ms = $backoff_ms == NULL ? 100 : $backoff_ms;
     }
 
     public function incrementRetryCount(): void {
@@ -61,8 +61,12 @@ class RetryRequestManager {
         return $status_code >= 200 && $status_code < 300;
     }
 
+    public function getBackoffDelayMs(): int {
+        return $this->backoff_ms * pow(2, $this->retry_count - 1);
+    }
+
     public function backoff(): void {
-        usleep(pow($this->backoff_ms, $this->retry_count) * 1000);
+        usleep($this->getBackoffDelayMs() * 1000);
     }
 }
 

--- a/src/Emitters/RetryRequestManager.php
+++ b/src/Emitters/RetryRequestManager.php
@@ -18,10 +18,12 @@
 
 namespace Snowplow\Tracker\Emitters;
 
+use Snowplow\Tracker\Constants;
+
 /**
  * Manages the state for retrying failed requests in emitters.
  */
-class RetryRequestManager {
+class RetryRequestManager extends Constants {
     /// The number of times the current request has been retried
     private int $retry_count = 0;
     /// The maximum number of times to retry a request. Defaults to 1.
@@ -53,8 +55,7 @@ class RetryRequestManager {
         }
 
         // don't retry certain 4xx codes, retry everything else
-        $dont_retry_codes = array(400, 401, 403, 410, 422);
-        return !in_array($status_code, $dont_retry_codes);
+        return !in_array($status_code, self::NO_RETRY_STATUS_CODES);
     }
 
     public function isGoodStatusCode(int $status_code): bool {

--- a/src/Emitters/RetryRequestManager.php
+++ b/src/Emitters/RetryRequestManager.php
@@ -1,0 +1,69 @@
+<?php
+/*
+    RetryRequestManager.php
+
+    Copyright (c) 2014-2023 Snowplow Analytics Ltd. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+*/
+
+namespace Snowplow\Tracker\Emitters;
+
+/**
+ * Manages the state for retrying failed requests in emitters.
+ */
+class RetryRequestManager {
+    /// The number of times the current request has been retried
+    private int $retry_count = 0;
+    /// The maximum number of times to retry a request
+    private int $max_retry_attempts;
+    /// The number of milliseconds to backoff before retrying a request
+    private int $backoff_ms;
+
+    public function __construct(int $max_retry_attempts = NULL, int $backoff_ms = NULL) {
+        $this->max_retry_attempts = $max_retry_attempts == NULL ? 1 : $max_retry_attempts;
+        $this->backoff_ms = $backoff_ms == NULL ? 10 : $backoff_ms;
+    }
+
+    public function incrementRetryCount(): void {
+        $this->retry_count++;
+    }
+
+    public function shouldRetryFailedRequest(): bool {
+        return $this->shouldRetryForStatusCode(0);
+    }
+
+    public function shouldRetryForStatusCode(int $status_code): bool {
+        if ($this->retry_count >= $this->max_retry_attempts) {
+            return false;
+        }
+
+        // successful requests should not be retried
+        if ($this->isGoodStatusCode($status_code)) {
+            return false;
+        }
+
+        // don't retry certain 4xx codes, retry everything else
+        $dont_retry_codes = array(400, 401, 403, 410, 422);
+        return !in_array($status_code, $dont_retry_codes);
+    }
+
+    public function isGoodStatusCode(int $status_code): bool {
+        return $status_code >= 200 && $status_code < 300;
+    }
+
+    public function backoff(): void {
+        usleep(pow($this->backoff_ms, $this->retry_count) * 1000);
+    }
+}
+
+?>

--- a/src/Emitters/SocketEmitter.php
+++ b/src/Emitters/SocketEmitter.php
@@ -49,10 +49,10 @@ class SocketEmitter extends Emitter {
      * @param bool|null $ssl - If the collector is using SSL
      * @param string|null $type - Type of request to be made (POST || GET)
      * @param float|int|null $timeout - Timeout for the socket connection
-     * @param int|null $buffer_size - Number of events to buffer before making a request to collector
+     * @param int|null $buffer_size - Number of events to buffer before making a POST request to collector
      * @param bool|null $debug - If debug is on
-     * @param int|null $max_retry_attempts - The maximum number of times to retry a request
-     * @param int|null $retry_backoff_ms - The number of milliseconds to backoff before retrying a request
+     * @param int|null $max_retry_attempts - The maximum number of times to retry a request. Defaults to 1.
+     * @param int|null $retry_backoff_ms - The number of milliseconds to backoff before retrying a request. Defaults to 100ms.
      */
     public function __construct($uri, $ssl = NULL, $type = NULL, $timeout = NULL, $buffer_size = NULL, $debug = NULL, $max_retry_attempts = NULL, $retry_backoff_ms = NULL) {
         $this->type    = $this->getRequestType($type);
@@ -160,7 +160,6 @@ class SocketEmitter extends Emitter {
             }
         }
 
-        // Get response for request
         $status_code = 0;
 
         if (!$closed) {

--- a/src/Emitters/SyncEmitter.php
+++ b/src/Emitters/SyncEmitter.php
@@ -44,8 +44,8 @@ class SyncEmitter extends Emitter {
      * @param string|null $type - Type of request to be made (POST || GET)
      * @param int|null $buffer_size - Number of events to buffer before making a POST request to collector
      * @param bool|null $debug - If debug is on
-     * @param int|null $max_retry_attempts - The maximum number of times to retry a request
-     * @param int|null $retry_backoff_ms - The number of milliseconds to backoff before retrying a request
+     * @param int|null $max_retry_attempts - The maximum number of times to retry a request. Defaults to 1.
+     * @param int|null $retry_backoff_ms - The number of milliseconds to backoff before retrying a request. Defaults to 100ms.
      */
     public function __construct($uri, $protocol = NULL, $type = NULL, $buffer_size = NULL, $debug = false, $max_retry_attempts = NULL, $retry_backoff_ms = NULL) {
         $this->type = $this->getRequestType($type);

--- a/src/Emitters/SyncEmitter.php
+++ b/src/Emitters/SyncEmitter.php
@@ -21,6 +21,7 @@
 
 namespace Snowplow\Tracker\Emitters;
 use Snowplow\Tracker\Emitter;
+use Snowplow\Tracker\Emitters\RetryRequestManager;
 use Requests;
 use Exception;
 
@@ -32,19 +33,25 @@ class SyncEmitter extends Emitter {
     private $url;
     private $debug;
     private $requests_results;
+    private $max_retry_attempts;
+    private $retry_backoff_ms;
 
     /**
      * Creates a Synchronous Emitter
      *
-     * @param string $uri
-     * @param string|null $protocol
-     * @param string|null $type
-     * @param int|null $buffer_size
-     * @param bool $debug
+     * @param string $uri - Collector URI to be used for the request
+     * @param string|null $protocol - Protocol to be used for the request (http || https)
+     * @param string|null $type - Type of request to be made (POST || GET)
+     * @param int|null $buffer_size - Number of events to buffer before making a POST request to collector
+     * @param bool|null $debug - If debug is on
+     * @param int|null $max_retry_attempts - The maximum number of times to retry a request
+     * @param int|null $retry_backoff_ms - The number of milliseconds to backoff before retrying a request
      */
-    public function __construct($uri, $protocol = NULL, $type = NULL, $buffer_size = NULL, $debug = false) {
+    public function __construct($uri, $protocol = NULL, $type = NULL, $buffer_size = NULL, $debug = false, $max_retry_attempts = NULL, $retry_backoff_ms = NULL) {
         $this->type = $this->getRequestType($type);
         $this->url  = $this->getCollectorUrl($this->type, $uri, $protocol);
+        $this->max_retry_attempts = $max_retry_attempts;
+        $this->retry_backoff_ms = $retry_backoff_ms;
 
         // If debug is on create a requests_results array
         if ($debug === true) {
@@ -98,9 +105,13 @@ class SyncEmitter extends Emitter {
      * @param string $type - The type of the Request
      * @return bool|string - Return true if successful request or an error string
      */
-    private function curlRequest($data, $type) {
+    private function curlRequest($data, $type, $retry_request_manager = NULL) {
         $res = true;
         $res_ = "";
+
+        if ($retry_request_manager == NULL) {
+            $retry_request_manager = new RetryRequestManager($this->max_retry_attempts, $this->retry_backoff_ms);
+        }
 
         // Create a cURL handle, set transfer options and execute
         $ch = curl_init($this->url);
@@ -121,12 +132,15 @@ class SyncEmitter extends Emitter {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_exec($ch);
 
+        $status_code = 0;
+
         if (!curl_errno($ch)) {
+            $info = curl_getinfo($ch);
+            $status_code = $info['http_code'];
             if ($this->debug) {
-                $info = curl_getinfo($ch);
-                $this->storeRequestResults($info['http_code'], $data);
+                $this->storeRequestResults($status_code, $data);
                 if ($info['http_code'] != 200) {
-                    $res_.= "Sync ".$type." Request Failed: ".$info['http_code'];
+                    $res_.= "Sync ".$type." Request Failed: ".$status_code;
                 }
             }
         }
@@ -138,6 +152,14 @@ class SyncEmitter extends Emitter {
         }
         // Close handle
         curl_close($ch);
+
+        // Retry request if necessary
+        if ($retry_request_manager->shouldRetryForStatusCode($status_code)) {
+            $retry_request_manager->incrementRetryCount();
+            $retry_request_manager->backoff();
+
+            return $this->curlRequest($data, $type, $retry_request_manager);
+        }
 
         // If request failed return error string, else return true
         if ($res_ != "") {

--- a/tests/mountebank_mocks/imposter.json
+++ b/tests/mountebank_mocks/imposter.json
@@ -1,7 +1,42 @@
 {
   "port": 4545,
   "protocol": "http",
-  "stubs": [{
+  "stubs": [
+    {
+      "responses": [{ 
+        "is": {
+          "statusCode": 500,
+          "body": "Failed Snowplow Request"
+        }
+      }],
+      "predicates": [
+        {
+          "contains": {
+            "path": "/fail_500/i",
+            "method": "GET",
+            "body": ""
+          }
+        }
+      ]
+    },
+    {
+      "responses": [{ 
+        "is": {
+          "statusCode": 400,
+          "body": "Failed Snowplow Request"
+        }
+      }],
+      "predicates": [
+        {
+          "contains": {
+            "path": "/fail_400/i",
+            "method": "GET",
+            "body": ""
+          }
+        }
+      ]
+    },
+    {
       "responses": [
         {
           "is": {

--- a/tests/tests/EmitterTests/RetryRequestManagerTest.php
+++ b/tests/tests/EmitterTests/RetryRequestManagerTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+    RetryRequestManagerTest.php
+
+    Copyright (c) 2014-2023 Snowplow Analytics Ltd. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+*/
+
+use Snowplow\Tracker\Emitters\RetryRequestManager;
+use PHPUnit\Framework\TestCase;
+
+class RetryRequestManagerTest extends TestCase {
+
+    public function testIncreasesBackoffDelayExponentially() {
+        $retry = new RetryRequestManager();
+        $retry->incrementRetryCount();
+        $this->assertEquals(100, $retry->getBackoffDelayMs());
+        $retry->incrementRetryCount();
+        $this->assertEquals(200, $retry->getBackoffDelayMs());
+        $retry->incrementRetryCount();
+        $this->assertEquals(400, $retry->getBackoffDelayMs());
+        $retry->incrementRetryCount();
+        $this->assertEquals(800, $retry->getBackoffDelayMs());
+    }
+
+    public function testRetriesOnFailureStatusCodes() {
+        $retry = new RetryRequestManager();
+        $this->assertTrue($retry->shouldRetryForStatusCode(0));
+        $this->assertTrue($retry->shouldRetryForStatusCode(404));
+        $this->assertTrue($retry->shouldRetryForStatusCode(500));
+    }
+
+    public function doesntRetryOnSome4xxFailureStatusCodes() {
+        $retry = new RetryRequestManager();
+        $this->assertTrue($retry->shouldRetryForStatusCode(400));
+        $this->assertTrue($retry->shouldRetryForStatusCode(401));
+    }
+
+    public function testDoesntRetryOnSuccessStatusCodes() {
+        $retry = new RetryRequestManager();
+        $this->assertFalse($retry->shouldRetryForStatusCode(200));
+        $this->assertFalse($retry->shouldRetryForStatusCode(201));
+    }
+
+    public function testDoesntRetryAfterMaxRetries() {
+        $retry = new RetryRequestManager(2);
+        $this->assertTrue($retry->shouldRetryForStatusCode(500));
+        $retry->incrementRetryCount();
+        $this->assertTrue($retry->shouldRetryForStatusCode(500));
+        $retry->incrementRetryCount();
+        $this->assertFalse($retry->shouldRetryForStatusCode(500));
+    }
+}

--- a/tests/tests/EmitterTests/SocketEmitterTest.php
+++ b/tests/tests/EmitterTests/SocketEmitterTest.php
@@ -42,14 +42,14 @@ class SocketEmitterTest extends TestCase {
         }
     }
 
-    private function returnTracker($type, $debug, $uri) {
+    private function returnTracker($type, $debug, $uri, $max_retries = 1) {
         $subject = new Subject();
-        $e1 = $this->returnSocketEmitter($type, $uri, $debug);
+        $e1 = $this->returnSocketEmitter($type, $uri, $debug, $max_retries);
         return new Tracker($e1, $subject, NULL, NULL, true);
     }
 
-    private function returnSocketEmitter($type, $uri, $debug) {
-        return new SocketEmitter($uri, NULL, $type, NULL, NULL, $debug);
+    private function returnSocketEmitter($type, $uri, $debug, $max_retries = 1) {
+        return new SocketEmitter($uri, NULL, $type, NULL, NULL, $debug, $max_retries);
     }
 
     // Tests
@@ -98,5 +98,47 @@ class SocketEmitterTest extends TestCase {
             $emitter->returnSocket());
         $this->assertEquals(false,
             $emitter->returnSocketIsFailed());
+    }
+
+    public function testRetriesWith500ResponseCode() {
+        $tracker = $this->returnTracker("GET", true, $this->uri."/fail_500");
+        $tracker->flushEmitters();
+        for ($i = 0; $i < 1; $i++) {
+            $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
+        }
+        $tracker->flushEmitters();
+
+        //Asserts
+        $this->requestResultAssert($tracker->returnEmitters(), 500);
+        $this->assertEquals(2, count($tracker->returnEmitters()[0]->returnRequestResults()));
+        $tracker->turnOffDebug(true);
+    }
+
+    public function testRetriesTwiceWith500ResponseCode() {
+        $tracker = $this->returnTracker("GET", true, $this->uri."/fail_500", 2);
+        $tracker->flushEmitters();
+        for ($i = 0; $i < 1; $i++) {
+            $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
+        }
+        $tracker->flushEmitters();
+
+        //Asserts
+        $this->requestResultAssert($tracker->returnEmitters(), 500);
+        $this->assertEquals(3, count($tracker->returnEmitters()[0]->returnRequestResults()));
+        $tracker->turnOffDebug(true);
+    }
+
+    public function testDoesntRetryWith400ResponseCode() {
+        $tracker = $this->returnTracker("GET", true, $this->uri."/fail_400");
+        $tracker->flushEmitters();
+        for ($i = 0; $i < 1; $i++) {
+            $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
+        }
+        $tracker->flushEmitters();
+
+        //Asserts
+        $this->requestResultAssert($tracker->returnEmitters(), 400);
+        $this->assertEquals(1, count($tracker->returnEmitters()[0]->returnRequestResults()));
+        $tracker->turnOffDebug(true);
     }
 }


### PR DESCRIPTION
Issue #140

Adds retry mechanism to two emitters: socket and sync emitters. The socket emitter already had a sort of a retry mechanism but it wasn't applied on failure status codes, didn't have a backoff period and also retried only once.

The new retry has the following features:

1. Configurable max number of retries. The default max number of retries is 1 to reflect the previous setting in the socket emitter.
2. Exponential backoff period with the base 100ms.
3. Retries on all 5xx and 4xx status codes except for 400, 401, 403, 410, 422.

The retry was not added to the file and curl emitters because these behave differently. They use the curl multi API which executes multiple curl requests to the collector at once asynchronously. While it would be possible to implement a retry capability, it's not straightforward so I decided to go for the low hanging fruit first and implement on socket and sync emitters.

This PR also fixes a problem in the socket emitter, where the tracker did not read the request response which resulted in the requests being ended prematurely and potentially events could be lost. Instead, the socket emitter now always reads the response and parses the status code.

[Documentation PR here](https://github.com/snowplow/documentation/pull/562/files).