### PR TITLE
Release/0.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.7.0 (2023-08-03)
+--------------------------
+Add retry capability for events that failed to send to collector in socket and sync emitter (#135)
+
 Version 0.6.1 (2022-12-21)
 --------------------------
 Fix curl_multi_exec deprecated functionality error (#121)

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -60,6 +60,7 @@ class Constants {
     const DEFAULT_PROTOCOL      = "http";
     const DEFAULT_SSL           = false;
     const DEFAULT_REQ_TYPE      = "POST";
+    const NO_RETRY_STATUS_CODES = array(400, 401, 403, 410, 422);
 
     /**
      * Settings for the Synchronous Emitter

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -45,7 +45,7 @@ class Constants {
      * - SSL: the default for whether or not to use SSL Encryption
      * - Type: the default for what type of request the emitter will be making (POST or GET)
      */
-    const TRACKER_VERSION       = "php-0.6.1";
+    const TRACKER_VERSION       = "php-0.7.0";
     const DEFAULT_BASE_64       = true;
     const DEBUG_LOG_FILES       = true;
     const CONTEXT_SCHEMA        = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";

--- a/src/Emitters/RetryRequestManager.php
+++ b/src/Emitters/RetryRequestManager.php
@@ -1,0 +1,74 @@
+<?php
+/*
+    RetryRequestManager.php
+
+    Copyright (c) 2014-2023 Snowplow Analytics Ltd. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+*/
+
+namespace Snowplow\Tracker\Emitters;
+
+use Snowplow\Tracker\Constants;
+
+/**
+ * Manages the state for retrying failed requests in emitters.
+ */
+class RetryRequestManager extends Constants {
+    /// The number of times the current request has been retried
+    private int $retry_count = 0;
+    /// The maximum number of times to retry a request. Defaults to 1.
+    private int $max_retry_attempts;
+    /// The number of milliseconds to backoff before retrying a request. Defaults to 100ms.
+    private int $backoff_ms;
+
+    public function __construct(int $max_retry_attempts = NULL, int $backoff_ms = NULL) {
+        $this->max_retry_attempts = $max_retry_attempts == NULL ? 1 : $max_retry_attempts;
+        $this->backoff_ms = $backoff_ms == NULL ? 100 : $backoff_ms;
+    }
+
+    public function incrementRetryCount(): void {
+        $this->retry_count++;
+    }
+
+    public function shouldRetryFailedRequest(): bool {
+        return $this->shouldRetryForStatusCode(0);
+    }
+
+    public function shouldRetryForStatusCode(int $status_code): bool {
+        if ($this->retry_count >= $this->max_retry_attempts) {
+            return false;
+        }
+
+        // successful requests should not be retried
+        if ($this->isGoodStatusCode($status_code)) {
+            return false;
+        }
+
+        // don't retry certain 4xx codes, retry everything else
+        return !in_array($status_code, self::NO_RETRY_STATUS_CODES);
+    }
+
+    public function isGoodStatusCode(int $status_code): bool {
+        return $status_code >= 200 && $status_code < 300;
+    }
+
+    public function getBackoffDelayMs(): int {
+        return $this->backoff_ms * pow(2, $this->retry_count - 1);
+    }
+
+    public function backoff(): void {
+        usleep($this->getBackoffDelayMs() * 1000);
+    }
+}
+
+?>

--- a/src/Emitters/SocketEmitter.php
+++ b/src/Emitters/SocketEmitter.php
@@ -21,6 +21,7 @@
 
 namespace Snowplow\Tracker\Emitters;
 use Snowplow\Tracker\Emitter;
+use Snowplow\Tracker\Emitters\RetryRequestManager;
 use Exception;
 
 class SocketEmitter extends Emitter {
@@ -33,6 +34,8 @@ class SocketEmitter extends Emitter {
     private $timeout;
     private $debug;
     private $requests_results;
+    private $max_retry_attempts;
+    private $retry_backoff_ms;
 
     // Socket Parameters
 
@@ -42,18 +45,22 @@ class SocketEmitter extends Emitter {
     /**
      * Creates a Socket Emitter
      *
-     * @param string $uri
-     * @param bool|null $ssl
-     * @param string|null $type
-     * @param float|int|null $timeout
-     * @param int|null $buffer_size
-     * @param bool|null $debug
+     * @param string $uri - Collector URI to be used for the request
+     * @param bool|null $ssl - If the collector is using SSL
+     * @param string|null $type - Type of request to be made (POST || GET)
+     * @param float|int|null $timeout - Timeout for the socket connection
+     * @param int|null $buffer_size - Number of events to buffer before making a POST request to collector
+     * @param bool|null $debug - If debug is on
+     * @param int|null $max_retry_attempts - The maximum number of times to retry a request. Defaults to 1.
+     * @param int|null $retry_backoff_ms - The number of milliseconds to backoff before retrying a request. Defaults to 100ms.
      */
-    public function __construct($uri, $ssl = NULL, $type = NULL, $timeout = NULL, $buffer_size = NULL, $debug = NULL) {
+    public function __construct($uri, $ssl = NULL, $type = NULL, $timeout = NULL, $buffer_size = NULL, $debug = NULL, $max_retry_attempts = NULL, $retry_backoff_ms = NULL) {
         $this->type    = $this->getRequestType($type);
         $this->uri     = $uri;
         $this->ssl     = $ssl == NULL ? self::DEFAULT_SSL : (bool) $ssl;
         $this->timeout = $timeout == NULL ? self::SOCKET_TIMEOUT : $timeout;
+        $this->max_retry_attempts = $max_retry_attempts;
+        $this->retry_backoff_ms = $retry_backoff_ms;
 
         // If debug is on create a requests_results array
         if ($debug === true) {
@@ -126,11 +133,15 @@ class SocketEmitter extends Emitter {
      * @param bool $retry - If we want to allow the function to make a second attempt.
      * @return bool - Returns if write was successful.
      */
-    private function makeRequest($data, $retry = true) {
+    private function makeRequest($data, $retry_request_manager = NULL) {
         $bytes_written = 0;
         $bytes_total = strlen($data);
         $closed = false;
         $res_ = "";
+
+        if ($retry_request_manager == NULL) {
+            $retry_request_manager = new RetryRequestManager($this->max_retry_attempts, $this->retry_backoff_ms);
+        }
 
         // Try to send data while bytes still have to be written to the socket
         while (!$closed && $bytes_written < $bytes_total) {
@@ -141,7 +152,7 @@ class SocketEmitter extends Emitter {
                 $res_.= "Error: fwrite exception - ".$e."\n";
                 $closed = true;
             }
-            if (!isset($written) || !$written) {
+            if (!isset($written) || $written === false) {
                 $closed = true;
             }
             else {
@@ -149,29 +160,39 @@ class SocketEmitter extends Emitter {
             }
         }
 
-        // If the socket could not be written attempt again
-        if ($closed) {
-            fclose($this->socket);
-            if ($retry) {
-                $socket_made = $this->makeSocket();
-                if (is_bool($socket_made) && $socket_made) {
-                    return $this->makeRequest($data, false);
-                }
-                else {
-                    return "Error: Socket could not be created\n".$socket_made."\n".$res_;
-                }
-            }
-            else {
-                return "Error: socket cannot be written after retry\n".$res_;
-            }
-        }
+        $status_code = 0;
 
-        // If debug is on store the request result
-        if ($this->debug) {
-            $this->storeRequestResults(fread($this->socket, 1024), $data);
+        if (!$closed) {
+            $res = fread($this->socket, 2048);
+            $status_code = $this->parseStatusCode($res);
+
+            // If debug is on store the request result
+            if ($this->debug) {
+                $this->storeRequestResults($res, $data);
+            }
         }
 
         fclose($this->socket);
+
+        // If the socket could not be written attempt again
+        if (($closed && $retry_request_manager->shouldRetryFailedRequest()) ||
+            $retry_request_manager->shouldRetryForStatusCode($status_code)) {
+            $retry_request_manager->incrementRetryCount();
+            $retry_request_manager->backoff();
+
+            $socket_made = $this->makeSocket();
+            if (is_bool($socket_made) && $socket_made) {
+                return $this->makeRequest($data, $retry_request_manager);
+            }
+            else {
+                return "Error: Socket could not be created\n".$socket_made."\n".$res_;
+            }
+        } else if ($closed) {
+            return "Error: socket cannot be written after retry\n".$res_;
+        } else if (!$retry_request_manager->isGoodStatusCode($status_code)) {
+            return "Error: collector responded with status code ".$status_code.", won't retry";
+        }
+
         return true;
     }
 
@@ -329,6 +350,12 @@ class SocketEmitter extends Emitter {
      */
     public function returnRequestResults() {
         return $this->requests_results;
+    }
+
+    private function parseStatusCode($res) {
+        $contents = explode("\n", $res);
+        $status = explode(" ", $contents[0], 3);
+        return $status[1];
     }
 
     /**

--- a/tests/mountebank_mocks/imposter.json
+++ b/tests/mountebank_mocks/imposter.json
@@ -1,7 +1,42 @@
 {
   "port": 4545,
   "protocol": "http",
-  "stubs": [{
+  "stubs": [
+    {
+      "responses": [{ 
+        "is": {
+          "statusCode": 500,
+          "body": "Failed Snowplow Request"
+        }
+      }],
+      "predicates": [
+        {
+          "contains": {
+            "path": "/fail_500/i",
+            "method": "GET",
+            "body": ""
+          }
+        }
+      ]
+    },
+    {
+      "responses": [{ 
+        "is": {
+          "statusCode": 400,
+          "body": "Failed Snowplow Request"
+        }
+      }],
+      "predicates": [
+        {
+          "contains": {
+            "path": "/fail_400/i",
+            "method": "GET",
+            "body": ""
+          }
+        }
+      ]
+    },
+    {
       "responses": [
         {
           "is": {

--- a/tests/tests/EmitterTests/RetryRequestManagerTest.php
+++ b/tests/tests/EmitterTests/RetryRequestManagerTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+    RetryRequestManagerTest.php
+
+    Copyright (c) 2014-2023 Snowplow Analytics Ltd. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License
+    Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the Apache License Version 2.0 for the specific
+    language governing permissions and limitations there under.
+*/
+
+use Snowplow\Tracker\Emitters\RetryRequestManager;
+use PHPUnit\Framework\TestCase;
+
+class RetryRequestManagerTest extends TestCase {
+
+    public function testIncreasesBackoffDelayExponentially() {
+        $retry = new RetryRequestManager();
+        $retry->incrementRetryCount();
+        $this->assertEquals(100, $retry->getBackoffDelayMs());
+        $retry->incrementRetryCount();
+        $this->assertEquals(200, $retry->getBackoffDelayMs());
+        $retry->incrementRetryCount();
+        $this->assertEquals(400, $retry->getBackoffDelayMs());
+        $retry->incrementRetryCount();
+        $this->assertEquals(800, $retry->getBackoffDelayMs());
+    }
+
+    public function testRetriesOnFailureStatusCodes() {
+        $retry = new RetryRequestManager();
+        $this->assertTrue($retry->shouldRetryForStatusCode(0));
+        $this->assertTrue($retry->shouldRetryForStatusCode(404));
+        $this->assertTrue($retry->shouldRetryForStatusCode(500));
+    }
+
+    public function doesntRetryOnSome4xxFailureStatusCodes() {
+        $retry = new RetryRequestManager();
+        $this->assertTrue($retry->shouldRetryForStatusCode(400));
+        $this->assertTrue($retry->shouldRetryForStatusCode(401));
+    }
+
+    public function testDoesntRetryOnSuccessStatusCodes() {
+        $retry = new RetryRequestManager();
+        $this->assertFalse($retry->shouldRetryForStatusCode(200));
+        $this->assertFalse($retry->shouldRetryForStatusCode(201));
+    }
+
+    public function testDoesntRetryAfterMaxRetries() {
+        $retry = new RetryRequestManager(2);
+        $this->assertTrue($retry->shouldRetryForStatusCode(500));
+        $retry->incrementRetryCount();
+        $this->assertTrue($retry->shouldRetryForStatusCode(500));
+        $retry->incrementRetryCount();
+        $this->assertFalse($retry->shouldRetryForStatusCode(500));
+    }
+}

--- a/tests/tests/EmitterTests/SocketEmitterTest.php
+++ b/tests/tests/EmitterTests/SocketEmitterTest.php
@@ -42,14 +42,14 @@ class SocketEmitterTest extends TestCase {
         }
     }
 
-    private function returnTracker($type, $debug, $uri) {
+    private function returnTracker($type, $debug, $uri, $max_retries = 1) {
         $subject = new Subject();
-        $e1 = $this->returnSocketEmitter($type, $uri, $debug);
+        $e1 = $this->returnSocketEmitter($type, $uri, $debug, $max_retries);
         return new Tracker($e1, $subject, NULL, NULL, true);
     }
 
-    private function returnSocketEmitter($type, $uri, $debug) {
-        return new SocketEmitter($uri, NULL, $type, NULL, NULL, $debug);
+    private function returnSocketEmitter($type, $uri, $debug, $max_retries = 1) {
+        return new SocketEmitter($uri, NULL, $type, NULL, NULL, $debug, $max_retries);
     }
 
     // Tests
@@ -98,5 +98,47 @@ class SocketEmitterTest extends TestCase {
             $emitter->returnSocket());
         $this->assertEquals(false,
             $emitter->returnSocketIsFailed());
+    }
+
+    public function testRetriesWith500ResponseCode() {
+        $tracker = $this->returnTracker("GET", true, $this->uri."/fail_500");
+        $tracker->flushEmitters();
+        for ($i = 0; $i < 1; $i++) {
+            $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
+        }
+        $tracker->flushEmitters();
+
+        //Asserts
+        $this->requestResultAssert($tracker->returnEmitters(), 500);
+        $this->assertEquals(2, count($tracker->returnEmitters()[0]->returnRequestResults()));
+        $tracker->turnOffDebug(true);
+    }
+
+    public function testRetriesTwiceWith500ResponseCode() {
+        $tracker = $this->returnTracker("GET", true, $this->uri."/fail_500", 2);
+        $tracker->flushEmitters();
+        for ($i = 0; $i < 1; $i++) {
+            $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
+        }
+        $tracker->flushEmitters();
+
+        //Asserts
+        $this->requestResultAssert($tracker->returnEmitters(), 500);
+        $this->assertEquals(3, count($tracker->returnEmitters()[0]->returnRequestResults()));
+        $tracker->turnOffDebug(true);
+    }
+
+    public function testDoesntRetryWith400ResponseCode() {
+        $tracker = $this->returnTracker("GET", true, $this->uri."/fail_400");
+        $tracker->flushEmitters();
+        for ($i = 0; $i < 1; $i++) {
+            $tracker->trackPageView("www.example.com", "example", "www.referrer.com");
+        }
+        $tracker->flushEmitters();
+
+        //Asserts
+        $this->requestResultAssert($tracker->returnEmitters(), 400);
+        $this->assertEquals(1, count($tracker->returnEmitters()[0]->returnRequestResults()));
+        $tracker->turnOffDebug(true);
     }
 }


### PR DESCRIPTION
This minor releases updates the socket and sync emitters, adding the capability to retry sending requests to collector that failed. Requests are retried in case connection to the collector is not established or the collector returns with a 4xx or 5xx status code (except for 400, 401, 403, 410, 422). The number of times to retry is configurable. There is also an exponential backoff period between subsequent retry attempts.

**Enhancements**
* Add retry capability for events that failed to send to collector in socket and sync emitter (#135)