### PR TITLE
Add Emitter Server Anonymization support

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -61,6 +61,7 @@ class Constants {
     const DEFAULT_SSL           = false;
     const DEFAULT_REQ_TYPE      = "POST";
     const NO_RETRY_STATUS_CODES = array(400, 401, 403, 410, 422);
+    const SERVER_ANONYMIZATION  = "SP-Anonymous";
 
     /**
      * Settings for the Synchronous Emitter


### PR DESCRIPTION
Enable [Server-side Anonymization](https://docs.snowplow.io/docs/sources/trackers/mobile-trackers/anonymous-tracking/#3-server-side-anonymisation) support to all PHP Emitters.

This allows the PHP tracker to generate events without associating Network User IDs with events.
This may be desirable for compliance reasons, or simplifying user stitching data models.