### PR TITLE
fix implicit nullable param to support PHP8.4 (#154)

### DIFF
--- a/src/Emitters/CurlEmitter.php
+++ b/src/Emitters/CurlEmitter.php
@@ -31,7 +31,7 @@ class CurlEmitter extends Emitter {
     private $debug;
     private $requests_results;
     private $debug_payloads;
-    private $server_anoymization;
+    private $server_anonymization;
 
     // Curl Specific Parameters
 

--- a/src/Emitters/RetryRequestManager.php
+++ b/src/Emitters/RetryRequestManager.php
@@ -31,7 +31,7 @@ class RetryRequestManager extends Constants {
     /// The number of milliseconds to backoff before retrying a request. Defaults to 100ms.
     private int $backoff_ms;
 
-    public function __construct(int $max_retry_attempts = NULL, int $backoff_ms = NULL) {
+    public function __construct(?int $max_retry_attempts = NULL, ?int $backoff_ms = NULL) {
         $this->max_retry_attempts = $max_retry_attempts == NULL ? 1 : $max_retry_attempts;
         $this->backoff_ms = $backoff_ms == NULL ? 100 : $backoff_ms;
     }


### PR DESCRIPTION
Fixes: 
 - Used explicit nullable type to support PHP8.4 in the RequestManager
 - typo  in Emitter::server_ano`n`ymization